### PR TITLE
Fix property URI prefixes in toneshifteq.ttl

### DIFF
--- a/EQ12/lv2/toneshifteq.ttl
+++ b/EQ12/lv2/toneshifteq.ttl
@@ -97,7 +97,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 40 ;
         lv2:minimum 20 ;
         lv2:maximum 60 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -166,7 +166,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 70 ;
         lv2:minimum 40 ;
         lv2:maximum 100 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -235,7 +235,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 120 ;
         lv2:minimum 70 ;
         lv2:maximum 180 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -304,7 +304,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 210 ;
         lv2:minimum 120 ;
         lv2:maximum 300 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -373,7 +373,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 370 ;
         lv2:minimum 200 ;
         lv2:maximum 550 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -442,7 +442,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 650 ;
         lv2:minimum 350 ;
         lv2:maximum 900 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -511,7 +511,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 1150 ;
         lv2:minimum 650 ;
         lv2:maximum 1600 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -580,7 +580,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 2000 ;
         lv2:minimum 1100 ;
         lv2:maximum 2800 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -649,7 +649,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 3500 ;
         lv2:minimum 1800 ;
         lv2:maximum 5000 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -718,7 +718,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 6100 ;
         lv2:minimum 3500 ;
         lv2:maximum 9000 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -787,7 +787,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 10700 ;
         lv2:minimum 6000 ;
         lv2:maximum 15000 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -856,7 +856,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 18000 ;
         lv2:minimum 10000 ;
         lv2:maximum 20000 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -921,7 +921,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 19 ;
         lv2:minimum 19 ;
         lv2:maximum 2200 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 
@@ -944,7 +944,7 @@ guiext:ui <urn:brummer:toneshifteq_ui> ;
         lv2:default 22000 ;
         lv2:minimum 110 ;
         lv2:maximum 22000 ;
-        lv2:portProperty lv2:logarithmic ;
+        lv2:portProperty pprop:logarithmic ;
         units:unit units:hz ;
     ] ,
 


### PR DESCRIPTION
```
lv2lint 0.16.2
Copyright (c) 2016-2021 Hanspeter Portner (dev@open-music-kontrollers.ch)
Released under Artistic License 2.0 by Open Music Kontrollers
<urn:brummer:toneshifteq>
    [WARN]  Plugin License
              doap:license not found
              seeAlso: <http://lv2plug.in/ns/lv2core#Plugin>
    [WARN]  Plugin Author Email
              foaf:mbox not found
              seeAlso: <http://lv2plug.in/ns/lv2core#project>
    [WARN]  Plugin Author Homepage
              foaf:homepage not found
              seeAlso: <http://lv2plug.in/ns/lv2core#project>
  {4 : band1_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {10 : band2_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {16 : band3_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {22 : band4_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {28 : band5_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {34 : band6_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {40 : band7_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {46 : band8_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {52 : band9_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {58 : band10_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {64 : band11_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {70 : band12_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {76 : lowcut_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
  {78 : highcut_freq}
    [FAIL]  Port Properties
              lv2:portProperty <http://lv2plug.in/ns/lv2core#logarithmic> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#portProperty>
```